### PR TITLE
Return Marathon Application Service Labels as Spring Cloud Service In…

### DIFF
--- a/autoconfigure/src/test/java/info/developerblog/spring/cloud/marathon/discovery/MarathonDiscoveryClientErrorsTests.java
+++ b/autoconfigure/src/test/java/info/developerblog/spring/cloud/marathon/discovery/MarathonDiscoveryClientErrorsTests.java
@@ -25,7 +25,7 @@ public class MarathonDiscoveryClientErrorsTests {
         );
 
         when(marathonClient.getApps()).thenThrow(new MarathonException(404, "Not Found"));
-        when(marathonClient.getAppTasks(anyString())).thenThrow(new MarathonException(404, "Not Found"));
+        when(marathonClient.getApp(anyString())).thenThrow(new MarathonException(404, "Not Found"));
     }
 
     @Test

--- a/autoconfigure/src/test/java/info/developerblog/spring/cloud/marathon/discovery/MarathonDiscoveryClientTests.java
+++ b/autoconfigure/src/test/java/info/developerblog/spring/cloud/marathon/discovery/MarathonDiscoveryClientTests.java
@@ -86,12 +86,13 @@ public class MarathonDiscoveryClientTests {
 
     @Test
     public void test_list_of_instances() throws MarathonException {
-        GetAppTasksResponse tasksResponse = new GetAppTasksResponse();
+        GetAppResponse appResponse = new GetAppResponse();
 
-        when(marathonClient.getAppTasks("/app1"))
-                .thenReturn(tasksResponse);
+        when(marathonClient.getApp("/app1"))
+                .thenReturn(appResponse);
 
-        tasksResponse.setTasks(new ArrayList<>());
+        appResponse.setApp(new App());
+        appResponse.getApp().setTasks(new ArrayList<>());
 
         Task taskWithNoHealthChecks = new Task();
         taskWithNoHealthChecks.setAppId("/app1");
@@ -102,7 +103,7 @@ public class MarathonDiscoveryClientTests {
                 .collect(Collectors.toList())
         );
 
-        tasksResponse.getTasks().add(taskWithNoHealthChecks);
+        appResponse.getApp().getTasks().add(taskWithNoHealthChecks);
 
         Task taskWithAllGoodHealthChecks = new Task();
         taskWithAllGoodHealthChecks.setAppId("/app1");
@@ -125,7 +126,7 @@ public class MarathonDiscoveryClientTests {
 
         taskWithAllGoodHealthChecks.setHealthCheckResults(healthCheckResults);
 
-        tasksResponse.getTasks().add(taskWithAllGoodHealthChecks);
+        appResponse.getApp().getTasks().add(taskWithAllGoodHealthChecks);
 
         Task taskWithOneBadHealthCheck = new Task();
         taskWithOneBadHealthCheck.setAppId("/app1");
@@ -142,7 +143,7 @@ public class MarathonDiscoveryClientTests {
 
         taskWithOneBadHealthCheck.setHealthCheckResults(withBadHealthCheckResults);
 
-        tasksResponse.getTasks().add(taskWithOneBadHealthCheck);
+        appResponse.getApp().getTasks().add(taskWithOneBadHealthCheck);
 
         ReflectionAssert.assertReflectionEquals(
                 "should be two tasks",


### PR DESCRIPTION
Adjusted MarathonDiscoveryClient to return Marathon Application Labels (a map of key/value pairs) as the Spring Cloud Discovery ServiceInstance meta-data (also a map of key/value pairs).  This will facilitate applying Predicate Filters using Ribbon e.g. "fetch all service instances with the following key/value combinations".  This enables us to also announce service capabilities.